### PR TITLE
github/workflow: upgrade go version to go1.16 on CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,12 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.x
+        go-version: 1.16.x
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: go
 
     - name: Cache Go module and build cache
       uses: actions/cache@v2
@@ -45,11 +50,6 @@ jobs:
       run: |
         go mod download
         go mod vendor
-
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: go
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Upgrade go version to go1.16 on CodeQL.