### PR TITLE
Fix client capability for semantic tokens

### DIFF
--- a/capabilities_client.go
+++ b/capabilities_client.go
@@ -927,7 +927,7 @@ type SemanticTokensWorkspaceClientCapabilitiesRequests struct {
 
 	// Full is the client will send the "textDocument/semanticTokens/full" request
 	// if the server provides a corresponding handler.
-	Full bool `json:"full,omitempty"` // delta?: boolean
+	Full interface{} `json:"full,omitempty"`
 }
 
 // LinkedEditingRangeClientCapabilities capabilities specific to "textDocument/linkedEditingRange" requests.

--- a/capabilities_client.go
+++ b/capabilities_client.go
@@ -926,7 +926,9 @@ type SemanticTokensWorkspaceClientCapabilitiesRequests struct {
 	Range bool `json:"range,omitempty"`
 
 	// Full is the client will send the "textDocument/semanticTokens/full" request
-	// if the server provides a corresponding handler.
+	// if the server provides a corresponding handler. The client will send the
+	// `textDocument/semanticTokens/full/delta` request if the server provides a
+	// corresponding handler.
 	Full interface{} `json:"full,omitempty"`
 }
 

--- a/capabilities_client_gojay.go
+++ b/capabilities_client_gojay.go
@@ -1821,7 +1821,7 @@ var (
 // MarshalJSONObject implements gojay.MarshalerJSONObject.
 func (v *SemanticTokensWorkspaceClientCapabilitiesRequests) MarshalJSONObject(enc *gojay.Encoder) {
 	enc.BoolKeyOmitEmpty(keyRange, v.Range)
-	enc.BoolKeyOmitEmpty(keyFull, v.Full)
+	enc.AddInterfaceKey(keyFull, v.Full)
 }
 
 // IsNil implements gojay.MarshalerJSONObject.
@@ -1833,7 +1833,7 @@ func (v *SemanticTokensWorkspaceClientCapabilitiesRequests) UnmarshalJSONObject(
 	case keyRange:
 		return dec.Bool(&v.Range)
 	case keyFull:
-		return dec.Bool(&v.Full)
+		return dec.Interface(&v.Full)
 	}
 	return nil
 }


### PR DESCRIPTION
First of all, great to see you guys are making the effort to port the LSP specification to Go. I started experimenting with your package quite recently. I encountered a small problem when trying to unmarshal the `InitializeParams` as generated by `vscode-languageclient` with version `7.0.0`. VSCode generates the client capabilities automatically, but handling the payload of `InitializeParams` on the server side (written in Go using your protocol package) gives the following error:

```
Message: json: cannot unmarshal object into Go struct field SemanticTokensWorkspaceClientCapabilitiesRequests.capabilities.textDocument.semanticTokens.requests.full of type bool
```

It seems the following section of the `InitializeParams` JSON is the cause of the issue.
```
[...]
    "textDocument": {
      "semanticTokens": {
        "requests": {
          "range": true,
          "full": {
            "delta": true
          }
      }
    }
[...]
```

According to the official [specification](https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#semanticTokensClientCapabilities), the value for `full` can be either `boolean` or another embedded struct. 

This PR fixes the issue by adjusting the struct `SemanticTokensWorkspaceClientCapabilitiesRequests` in `capabilities_client.go`. It simply changes the type of `Full` from `bool` to `interface{}`. Let me know if you need more evidence or supporting files to reproduce the error.