### PR TITLE
fix: it must be possible to have a nil range to replace all content in the TextDocumentChangeEvent

### DIFF
--- a/text.go
+++ b/text.go
@@ -87,7 +87,7 @@ type DidSaveTextDocumentParams struct {
 // the new text is considered to be the full content of the document.
 type TextDocumentContentChangeEvent struct {
 	// Range is the range of the document that changed.
-	Range Range `json:"range"`
+	Range *Range `json:"range,omitempty"`
 
 	// RangeLength is the length of the range that got replaced.
 	RangeLength uint32 `json:"rangeLength,omitempty"`

--- a/text_test.go
+++ b/text_test.go
@@ -125,7 +125,7 @@ func TestDidChangeTextDocumentParams(t *testing.T) {
 		},
 		ContentChanges: []TextDocumentContentChangeEvent{
 			{
-				Range: Range{
+				Range: &Range{
 					Start: Position{
 						Line:      25,
 						Character: 1,
@@ -267,11 +267,12 @@ func TestTextDocumentContentChangeEvent(t *testing.T) {
 	t.Parallel()
 
 	const (
-		want        = `{"range":{"start":{"line":25,"character":1},"end":{"line":25,"character":3}},"rangeLength":2,"text":"testText"}`
-		wantInvalid = `{"range":{"start":{"line":2,"character":1},"end":{"line":3,"character":4}},"rangeLength":3,"text":"invalidText"}`
+		want           = `{"range":{"start":{"line":25,"character":1},"end":{"line":25,"character":3}},"rangeLength":2,"text":"testText"}`
+		wantInvalid    = `{"range":{"start":{"line":2,"character":1},"end":{"line":3,"character":4}},"rangeLength":3,"text":"invalidText"}`
+		wantReplaceAll = `{"text":"replace all"}`
 	)
 	wantType := TextDocumentContentChangeEvent{
-		Range: Range{
+		Range: &Range{
 			Start: Position{
 				Line:      25,
 				Character: 1,
@@ -283,6 +284,9 @@ func TestTextDocumentContentChangeEvent(t *testing.T) {
 		},
 		RangeLength: 2,
 		Text:        "testText",
+	}
+	wantReplaceAllType := TextDocumentContentChangeEvent{
+		Text: "replace all",
 	}
 
 	t.Run("Marshal", func(t *testing.T) {
@@ -306,6 +310,13 @@ func TestTextDocumentContentChangeEvent(t *testing.T) {
 				want:           wantInvalid,
 				wantMarshalErr: false,
 				wantErr:        true,
+			},
+			{
+				name:           "ReplaceAll",
+				field:          wantReplaceAllType,
+				want:           wantReplaceAll,
+				wantMarshalErr: false,
+				wantErr:        false,
 			},
 		}
 		for _, tt := range tests {


### PR DESCRIPTION
Replaces previous PR, because I accidentally did a PR from the main branch of my fork.