### PR TITLE
context: fix context key

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,19 +9,19 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
+type (
 	ctxLogger struct{}
 	ctxClient struct{}
 )
 
 // WithLogger returns the context with zap.Logger value.
 func WithLogger(ctx context.Context, logger *zap.Logger) context.Context {
-	return context.WithValue(ctx, ctxLogger, logger)
+	return context.WithValue(ctx, ctxLogger{}, logger)
 }
 
 // LoggerFromContext extracts zap.Logger from context.
 func LoggerFromContext(ctx context.Context) *zap.Logger {
-	logger, ok := ctx.Value(ctxLogger).(*zap.Logger)
+	logger, ok := ctx.Value(ctxLogger{}).(*zap.Logger)
 	if !ok {
 		return zap.NewNop()
 	}
@@ -31,5 +31,5 @@ func LoggerFromContext(ctx context.Context) *zap.Logger {
 
 // WithClient returns the context with Client value.
 func WithClient(ctx context.Context, client Client) context.Context {
-	return context.WithValue(ctx, ctxClient, client)
+	return context.WithValue(ctx, ctxClient{}, client)
 }


### PR DESCRIPTION
Each context key must have its own type. Otherwise, keys will conflict.