### PR TITLE
Complete SemanticTokensOptions definition

### DIFF
--- a/basic.go
+++ b/basic.go
@@ -683,16 +683,16 @@ const (
 //
 // Here is an example how such a string can be constructed using JavaScript / TypeScript:
 //
-//  let markdown: MarkdownContent = {
-//   kind: MarkupKind.Markdown,
-//    value: [
-//    	'# Header',
-//    	'Some text',
-//    	'```typescript',
-//    'someCode();',
-//    '```'
-//    ].join('\n')
-//  };
+//	let markdown: MarkdownContent = {
+//	 kind: MarkupKind.Markdown,
+//	  value: [
+//	  	'# Header',
+//	  	'Some text',
+//	  	'```typescript',
+//	  'someCode();',
+//	  '```'
+//	  ].join('\n')
+//	};
 //
 // NOTE: clients might sanitize the return markdown. A client could decide to
 // remove HTML from the markdown to avoid script execution.

--- a/capabilities_client.go
+++ b/capabilities_client.go
@@ -1021,13 +1021,20 @@ type GeneralClientCapabilities struct {
 //
 // The following features from the ECMAScript 2020 regular expression specification are NOT mandatory for a client:
 //
-//  Assertions
+//	Assertions
+//
 // Lookahead assertion, Negative lookahead assertion, lookbehind assertion, negative lookbehind assertion.
-//  Character classes
+//
+//	Character classes
+//
 // Matching control characters using caret notation (e.g. "\cX") and matching UTF-16 code units (e.g. "\uhhhh").
-//  Group and ranges
+//
+//	Group and ranges
+//
 // Named capturing groups.
-//  Unicode property escapes
+//
+//	Unicode property escapes
+//
 // None of the features needs to be supported.
 //
 // The only regular expression flag that a client needs to support is "i" to specify a case insensitive search.

--- a/capabilities_server.go
+++ b/capabilities_server.go
@@ -426,11 +426,21 @@ type LinkedEditingRangeRegistrationOptions struct {
 	StaticRegistrationOptions
 }
 
+// SemanticTokensFullOptions option of SemanticTokensOptions to indicate support for full and/or full with delta semantic tokens requests.
+//
+// 
+type SemanticTokensFullOptions struct {
+    Delta bool `json:"delta"`
+}
+
 // SemanticTokensOptions option of semantic tokens provider server capabilities.
 //
 // @since 3.16.0.
 type SemanticTokensOptions struct {
 	WorkDoneProgressOptions
+    Legend *SemanticTokensLegend `json:"legend,omitempty"`
+    Range bool `json:"range"`
+    Full interface{} `json:"full,omitempty"`
 }
 
 // SemanticTokensRegistrationOptions registration option of semantic tokens provider server capabilities.

--- a/capabilities_server.go
+++ b/capabilities_server.go
@@ -428,7 +428,7 @@ type LinkedEditingRangeRegistrationOptions struct {
 
 // SemanticTokensFullOptions option of SemanticTokensOptions to indicate support for full and/or full with delta semantic tokens requests.
 type SemanticTokensFullOptions struct {
-    // The server supports deltas for full documents.
+	// The server supports deltas for full documents.
 	Delta bool `json:"delta"`
 }
 
@@ -437,12 +437,12 @@ type SemanticTokensFullOptions struct {
 // @since 3.16.0.
 type SemanticTokensOptions struct {
 	WorkDoneProgressOptions
-    // The legend used by the server
+	// The legend used by the server
 	Legend *SemanticTokensLegend `json:"legend,omitempty"`
-    // Server supports providing semantic tokens for a specific range of a document.
-	Range  bool                  `json:"range"`
-    // Server supports providing semantic tokens for a full document.
-	Full   interface{}           `json:"full,omitempty"`
+	// Server supports providing semantic tokens for a specific range of a document.
+	Range bool `json:"range"`
+	// Server supports providing semantic tokens for a full document.
+	Full interface{} `json:"full,omitempty"`
 }
 
 // SemanticTokensRegistrationOptions registration option of semantic tokens provider server capabilities.

--- a/capabilities_server.go
+++ b/capabilities_server.go
@@ -427,10 +427,8 @@ type LinkedEditingRangeRegistrationOptions struct {
 }
 
 // SemanticTokensFullOptions option of SemanticTokensOptions to indicate support for full and/or full with delta semantic tokens requests.
-//
-// 
 type SemanticTokensFullOptions struct {
-    Delta bool `json:"delta"`
+	Delta bool `json:"delta"`
 }
 
 // SemanticTokensOptions option of semantic tokens provider server capabilities.
@@ -438,9 +436,9 @@ type SemanticTokensFullOptions struct {
 // @since 3.16.0.
 type SemanticTokensOptions struct {
 	WorkDoneProgressOptions
-    Legend *SemanticTokensLegend `json:"legend,omitempty"`
-    Range bool `json:"range"`
-    Full interface{} `json:"full,omitempty"`
+	Legend *SemanticTokensLegend `json:"legend,omitempty"`
+	Range  bool                  `json:"range"`
+	Full   interface{}           `json:"full,omitempty"`
 }
 
 // SemanticTokensRegistrationOptions registration option of semantic tokens provider server capabilities.

--- a/capabilities_server.go
+++ b/capabilities_server.go
@@ -428,6 +428,7 @@ type LinkedEditingRangeRegistrationOptions struct {
 
 // SemanticTokensFullOptions option of SemanticTokensOptions to indicate support for full and/or full with delta semantic tokens requests.
 type SemanticTokensFullOptions struct {
+    // The server supports deltas for full documents.
 	Delta bool `json:"delta"`
 }
 
@@ -436,8 +437,11 @@ type SemanticTokensFullOptions struct {
 // @since 3.16.0.
 type SemanticTokensOptions struct {
 	WorkDoneProgressOptions
+    // The legend used by the server
 	Legend *SemanticTokensLegend `json:"legend,omitempty"`
+    // Server supports providing semantic tokens for a specific range of a document.
 	Range  bool                  `json:"range"`
+    // Server supports providing semantic tokens for a full document.
 	Full   interface{}           `json:"full,omitempty"`
 }
 

--- a/client.go
+++ b/client.go
@@ -45,6 +45,7 @@ func ClientHandler(client Client, handler jsonrpc2.Handler) jsonrpc2.Handler {
 }
 
 // clientDispatch implements jsonrpc2.Handler.
+//
 //nolint:funlen,cyclop
 func clientDispatch(ctx context.Context, client Client, reply jsonrpc2.Replier, req jsonrpc2.Request) (handled bool, err error) {
 	if ctx.Err() != nil {

--- a/language.go
+++ b/language.go
@@ -324,6 +324,7 @@ const (
 )
 
 // String implements fmt.Stringer.
+//
 //nolint:cyclop
 func (k CompletionItemKind) String() string {
 	switch k {
@@ -730,6 +731,7 @@ const (
 )
 
 // String implements fmt.Stringer.
+//
 //nolint:cyclop
 func (k SymbolKind) String() string {
 	switch k {

--- a/server.go
+++ b/server.go
@@ -25,6 +25,7 @@ func ServerDispatcher(conn jsonrpc2.Conn, logger *zap.Logger) Server {
 }
 
 // ServerHandler jsonrpc2.Handler of Language Server Prococol Server.
+//
 //nolint:unparam
 func ServerHandler(server Server, handler jsonrpc2.Handler) jsonrpc2.Handler {
 	h := func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
@@ -55,6 +56,7 @@ func ServerHandler(server Server, handler jsonrpc2.Handler) jsonrpc2.Handler {
 }
 
 // serverDispatch implements jsonrpc2.Handler.
+//
 //nolint:gocognit,funlen,gocyclo,cyclop
 func serverDispatch(ctx context.Context, server Server, reply jsonrpc2.Replier, req jsonrpc2.Request) (handled bool, err error) {
 	if ctx.Err() != nil {
@@ -1171,7 +1173,7 @@ func (s *server) CodeLensResolve(ctx context.Context, params *CodeLens) (_ *Code
 
 // ColorPresentation sends the request from the client to the server to obtain a list of presentations for a color value at a given location.
 //
-// Clients can use the result to
+// # Clients can use the result to
 //
 // - modify a color reference.
 // - show in a color picker and let users pick one of the presentations.


### PR DESCRIPTION
Closes #47 

Replacing go.lsp.dev/protocol with this repository and the following server capability:

```go
var semanticTokensOptions = lsp.SemanticTokensOptions{
                WorkDoneProgressOptions: lsp.WorkDoneProgressOptions{
                    WorkDoneProgress: false,
                },
                Legend: &lsp.SemanticTokensLegend{
                    TokenTypes: SemanticTokenLegend,
                    TokenModifiers: []lsp.SemanticTokenModifiers{},
                },
                Range: false,
                Full: &lsp.SemanticTokensFullOptions{ Delta: false },
           }
```

I actually successfully register the SemanticTokensProvider capability with my client.

```
2024/01/01 09:42:33 [SERVER]: ==========================================
2024/01/01 09:42:33 [SERVER]: Received message for method "textDocument/semanticTokens/full"
2024/01/01 09:42:33 [SERVER]: ------------------------------------------
```

I know that there is some tagging to be added, and probably a todo for the empty interface.