### PR TITLE
Fix `LogTraceParams.Verbose` type

### DIFF
--- a/general.go
+++ b/general.go
@@ -104,7 +104,7 @@ type LogTraceParams struct {
 
 	// Verbose is the additional information that can be computed if the "trace" configuration
 	// is set to "verbose".
-	Verbose TraceValue `json:"verbose,omitempty"`
+	Verbose string `json:"verbose,omitempty"`
 }
 
 // SetTraceParams params of SetTrace notification.

--- a/general_test.go
+++ b/general_test.go
@@ -341,12 +341,12 @@ func TestLogTraceParams(t *testing.T) {
 	t.Parallel()
 
 	const (
-		want    = `{"message":"testMessage","verbose":"verbose"}`
+		want    = `{"message":"testMessage","verbose":"testVerbose"}`
 		wantNil = `{"message":"testMessage"}`
 	)
 	wantType := LogTraceParams{
 		Message: "testMessage",
-		Verbose: TraceVerbose,
+		Verbose: "testVerbose",
 	}
 	wantTypeNil := LogTraceParams{
 		Message: "testMessage",


### PR DESCRIPTION
Fixes #57.